### PR TITLE
UserProcessScheduler.cc

### DIFF
--- a/dev/kernel/src/UserProcessScheduler.cc
+++ b/dev/kernel/src/UserProcessScheduler.cc
@@ -22,7 +22,6 @@
 #include <NeKit/KString.h>
 #include <SignalKit/Signals.h>
 #include <NeKit/Utils.h>
-#include <HALKit/AMD64/Processor.h>
 
 ///! BUGS: 0
 


### PR DESCRIPTION
rt_copy_memory calls were replaced with rt_copy_memory_safe. #include <NeKit/Utils.h> and #include <HALKit/AMD64/Processor.h>