### PR TITLE
chore: use `enum struct` instead of `enum class`.

### DIFF
--- a/docs/tex/core_process_scheduler.tex
+++ b/docs/tex/core_process_scheduler.tex
@@ -27,7 +27,7 @@
 {The following sample is C++ code.} {The smaller the value, the more critical the process.}
 
 \begin{verbatim}
-enum class AffinityKind : Int32 {
+enum struct AffinityKind : Int32 {
   kRealTime     = 100,
   kVeryHigh     = 150,
   kHigh         = 200,

--- a/scripts/debug_ahci_arm64.sh
+++ b/scripts/debug_ahci_arm64.sh
@@ -6,11 +6,11 @@ export ATA_DMA_SUPPORT=
 export DEBUG_SUPPORT=1
 
 cd src/kernel
-make -f arm64-desktop.make all
+make -f arm64-desktop.make  all
 cd ../boot
-make -f arm64-desktop.make all
+make -f arm64-desktop.make  all
 make -f arm64-desktop.make disk
 cd ../../
 ./tools/mk_img.py ./src/boot/src/nekernel-esp.img ./src/boot/src/root
 cd src/boot
-make -f arm64-desktop.make run-efi-arm64
+make -f arm64-desktop.make -j 8 run-efi-arm64

--- a/scripts/debug_ahci_x64.sh
+++ b/scripts/debug_ahci_x64.sh
@@ -6,11 +6,11 @@ export ATA_DMA_SUPPORT=
 export DEBUG_SUPPORT=1
 
 cd src/kernel
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 cd ../boot
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 make -f amd64-desktop.make disk
 cd ../../
 ./tools/mk_img.py ./src/boot/src/nekernel-esp.img ./src/boot/src/root
 cd src/boot
-make -f amd64-desktop.make run-efi-amd64-ahci
+make -f amd64-desktop.make -j 8 run-efi-amd64-ahci

--- a/scripts/debug_ata_x64.sh
+++ b/scripts/debug_ata_x64.sh
@@ -6,11 +6,11 @@ export ATA_DMA_SUPPORT=
 export DEBUG_SUPPORT=1
 
 cd src/kernel
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 cd ../boot
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 make -f amd64-desktop.make disk
 cd ../../
 ./tools/mk_img.py ./src/boot/src/nekernel-esp.img ./src/boot/src/root
 cd src/boot
-make -f amd64-desktop.make run-efi-amd64-ata-pio
+make -f amd64-desktop.make -j 8 run-efi-amd64-ata-pio

--- a/scripts/kernel_ci_x64.sh
+++ b/scripts/kernel_ci_x64.sh
@@ -6,4 +6,4 @@ export ATA_DMA_SUPPORT=
 export DEBUG_SUPPORT=1
 
 cd src/kernel
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all

--- a/scripts/release_ahci_x64.sh
+++ b/scripts/release_ahci_x64.sh
@@ -3,11 +3,11 @@
 export AHCI_SUPPORT=1
 
 cd src/kernel
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 cd ../boot
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 make -f amd64-desktop.make disk
 cd ../../
 ./tools/mk_img.py ./src/boot/src/nekernel-esp.img ./src/boot/src/root
 cd src/boot
-make -f amd64-desktop.make run-efi-amd64-ahci
+make -f amd64-desktop.make -j 8 run-efi-amd64-ahci

--- a/scripts/release_ata_x64.sh
+++ b/scripts/release_ata_x64.sh
@@ -3,11 +3,11 @@
 export ATA_PIO_SUPPORT=1
 
 cd src/kernel
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 cd ../boot
-make -f amd64-desktop.make all
+make -f amd64-desktop.make  all
 make -f amd64-desktop.make disk
 cd ../../
 ./tools/mk_img.py ./src/boot/src/nekernel-esp.img ./src/boot/src/root
 cd src/boot
-make -f amd64-desktop.make run-efi-amd64-ata-pio
+make -f amd64-desktop.make -j 8 run-efi-amd64-ata-pio

--- a/scripts/setup_arm64_project.sh
+++ b/scripts/setup_arm64_project.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 cd src/boot
-make -f arm64-desktop.make efi
-make -f arm64-desktop.make epm-img
+make -f arm64-desktop.make  efi
+make -f arm64-desktop.make  epm-img

--- a/scripts/setup_x64_project.sh
+++ b/scripts/setup_x64_project.sh
@@ -12,5 +12,5 @@ nebuild libSystem.json
 cd ../ddk
 nebuild ddk.json
 cd ../boot
-make -f amd64-desktop.make efi
-make -f amd64-desktop.make epm-img
+make -f amd64-desktop.make  efi
+make -f amd64-desktop.make  epm-img

--- a/src/boot/src/HEL/AMD64/BootEFI.cc
+++ b/src/boot/src/HEL/AMD64/BootEFI.cc
@@ -131,18 +131,18 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   kHandoverHeader->f_BitMapStart = nullptr;           /* Start of bitmap. */
   kHandoverHeader->f_BitMapSize  = kHandoverBitMapSz; /* Size of bitmap in bytes. */
 
-  UInt16 trials = 5;
+  UInt16 trials = 15;
 
   while (BS->AllocatePool(EfiLoaderData, kHandoverHeader->f_BitMapSize,
                           &kHandoverHeader->f_BitMapStart) != kEfiOk) {
     --trials;
 
-    if (!trials) {
-      writer.Write("BootZ: Unable to allocate sufficient memory, trying again with 2GB...\r");
+    if (trials) {
+      writer.Write("BootZ: Unable to allocate sufficient memory, trying again...\r");
 
-      trials = 3;
-
-      kHandoverHeader->f_BitMapSize = kHandoverBitMapSz / 2; /* Size of bitmap in bytes. */
+      if (kHandoverHeader->f_BitMapSize > 0)
+        kHandoverHeader->f_BitMapSize =
+            kHandoverHeader->f_BitMapSize / 2; /* Size of bitmap in bytes. */
 
       while (BS->AllocatePool(EfiLoaderData, kHandoverHeader->f_BitMapSize,
                               &kHandoverHeader->f_BitMapStart) != kEfiOk) {

--- a/src/boot/src/HEL/ARM64/BootEFI.cc
+++ b/src/boot/src/HEL/ARM64/BootEFI.cc
@@ -130,18 +130,18 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   kHandoverHeader->f_BitMapStart = nullptr;           /* Start of bitmap. */
   kHandoverHeader->f_BitMapSize  = kHandoverBitMapSz; /* Size of bitmap in bytes. */
 
-  UInt16 trials = 5;
+  UInt16 trials = 15;
 
   while (BS->AllocatePool(EfiLoaderData, kHandoverHeader->f_BitMapSize,
                           &kHandoverHeader->f_BitMapStart) != kEfiOk) {
     --trials;
 
-    if (!trials) {
-      writer.Write("BootZ: Unable to allocate sufficient memory, trying again with 2GB...\r");
+    if (trials) {
+      writer.Write("BootZ: Unable to allocate sufficient memory, trying again...\r");
 
-      trials = 3;
-
-      kHandoverHeader->f_BitMapSize = kHandoverBitMapSz / 2; /* Size of bitmap in bytes. */
+      if (kHandoverHeader->f_BitMapSize > 0)
+        kHandoverHeader->f_BitMapSize =
+            kHandoverHeader->f_BitMapSize / 2; /* Size of bitmap in bytes. */
 
       while (BS->AllocatePool(EfiLoaderData, kHandoverHeader->f_BitMapSize,
                               &kHandoverHeader->f_BitMapStart) != kEfiOk) {

--- a/src/kernel/HALKit/AMD64/Paging.h
+++ b/src/kernel/HALKit/AMD64/Paging.h
@@ -43,7 +43,7 @@ EXTERN_C Kernel::VoidPtr hal_read_cr3();  // @brief Page directory inside cr3 re
 
 namespace Kernel::HAL {
 namespace Detail {
-  enum class ControlRegisterBits {
+  enum struct ControlRegisterBits {
     kProtectedModeEnable = 0,
     kMonitorCoProcessor  = 1,
     kEmulation           = 2,

--- a/src/kernel/HALKit/AMD64/Storage/AHCI+Generic.cc
+++ b/src/kernel/HALKit/AMD64/Storage/AHCI+Generic.cc
@@ -277,7 +277,7 @@ STATIC Void drv_std_input_output_ahci(UInt64 lba, UInt8* buffer, SizeT sector_sz
   rtl_dma_flush(ptr, size_buffer);
 
   if (kSATAHba->Is & kSATAErrTaskFile) {
-    kout << "ahci: Task File Error during I/O.\r";
+    kout << "ahci: tf-error when doing I/O.\r";
 
     rtl_dma_free(size_buffer);
     err_global_get() = kErrorDiskIsCorrupted;

--- a/src/kernel/HALKit/ARM64/Paging.h
+++ b/src/kernel/HALKit/ARM64/Paging.h
@@ -68,7 +68,7 @@ struct PACKED PTE_4KB final {
 };
 
 namespace Detail {
-  enum class ControlRegisterBits {
+  enum struct ControlRegisterBits {
     ProtectedModeEnable = 0,
     MonitorCoProcessor  = 1,
     Emulation           = 2,

--- a/src/kernel/KernelKit/CoreProcessScheduler.h
+++ b/src/kernel/KernelKit/CoreProcessScheduler.h
@@ -142,7 +142,7 @@ struct PROCESS_SPECIAL_TREE {
 /// @brief Subsystem enum type.
 /***********************************************************************************/
 
-enum class ProcessSubsystem : Int32 {
+enum struct ProcessSubsystem : Int32 {
   kProcessSubsystemSecurity = 100,
   kProcessSubsystemUser,
   kProcessSubsystemService,
@@ -155,7 +155,7 @@ enum class ProcessSubsystem : Int32 {
 /***********************************************************************************/
 //! @brief Local Process status enum.
 /***********************************************************************************/
-enum class ProcessStatusKind : Int32 {
+enum struct ProcessStatusKind : Int32 {
   kInvalid  = 0,
   kStarting = 100,
   kRunning,
@@ -168,7 +168,7 @@ enum class ProcessStatusKind : Int32 {
 /***********************************************************************************/
 //! @brief Affinity is the amount of nano-seconds this process is going to run.
 /***********************************************************************************/
-enum class AffinityKind : Int32 {
+enum struct AffinityKind : Int32 {
   kInvalid      = 0,
   kRealTime     = 100,
   kVeryHigh     = 150,
@@ -221,7 +221,7 @@ using ProcessID = Int64;
 /***********************************************************************************/
 /// @note For User manager, tells where we run the code.
 /***********************************************************************************/
-enum class ProcessLevelRing : Int32 {
+enum struct ProcessLevelRing : Int32 {
   kRingStdUser   = 1,
   kRingSuperUser = 2,
   kRingGuestUser = 5,

--- a/src/kernel/KernelKit/PCI/DMA.h
+++ b/src/kernel/KernelKit/PCI/DMA.h
@@ -13,7 +13,7 @@
 #include <NeKit/Ref.h>
 
 namespace Kernel {
-enum class DmaKind {
+enum struct DmaKind {
   PCI = 10,  // Bus mastering is required to be turned on. Basiaclly a request
   // control system. 64-Bit access depends on the PAE bit and the device
   // (if Double Address Cycle is available)

--- a/src/kernel/KernelKit/PCI/Database.h
+++ b/src/kernel/KernelKit/PCI/Database.h
@@ -11,7 +11,7 @@
 namespace Kernel {
 namespace Types {
   // https://wiki.osdev.org/PCI
-  enum class PciDeviceKind : UChar {
+  enum struct PciDeviceKind : UChar {
     MassStorageController             = 0x1,
     NetworkController                 = 0x2,
     DisplayController                 = 0x3,

--- a/src/kernel/KernelKit/PCI/Device.h
+++ b/src/kernel/KernelKit/PCI/Device.h
@@ -10,7 +10,7 @@
 #include <NeKit/KernelPanic.h>
 
 namespace Kernel::PCI {
-enum class PciConfigKind : UShort {
+enum struct PciConfigKind : UShort {
   ConfigAddress = 0xCF8,
   ConfigData    = 0xCFC,
   CommandReg    = 0x0004,

--- a/src/kernel/KernelKit/UserMgr.h
+++ b/src/kernel/KernelKit/UserMgr.h
@@ -34,7 +34,7 @@
 namespace Kernel {
 class User;
 
-enum class UserRingKind : Int32 {
+enum struct UserRingKind : Int32 {
   kRingInvalid   = 0,
   kRingStdUser   = 444,
   kRingSuperUser = 666,

--- a/src/kernel/NeKit/Config.h
+++ b/src/kernel/NeKit/Config.h
@@ -79,7 +79,7 @@ using Lba = UInt64;
 
 using Char16 = char16_t;
 
-enum class Endian : UInt8 { kEndianInvalid, kEndianBig, kEndianLittle, kEndianMixed, kEndianCount };
+enum struct Endian : UInt8 { kEndianInvalid, kEndianBig, kEndianLittle, kEndianMixed, kEndianCount };
 
 /// @brief Forward object.
 /// @tparam Args the object type.

--- a/src/kernel/NeKit/Variant.h
+++ b/src/kernel/NeKit/Variant.h
@@ -15,7 +15,7 @@
 namespace Kernel {
 class Variant final {
  public:
-  enum class VariantKind {
+  enum struct VariantKind {
     kInvalid = 0,
     kString  = 200,
     kBlob,


### PR DESCRIPTION
chore: build scripts improvements.