### PR TITLE
[FEAT] Add IPXE for network booting purposes.

### DIFF
--- a/src/boot/src/HEL/AMD64/BootPlatform.cpp
+++ b/src/boot/src/HEL/AMD64/BootPlatform.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024-2025, Amlal El Mahrouss (amlal@nekernel.org)
+// Copyright 2024-2026, Amlal El Mahrouss (amlal@nekernel.org)
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 // Official repository: https://github.com/ne-foss-org/nekernel
 
@@ -7,6 +7,8 @@
 #include <BootKit/Protocol.h>
 
 #ifdef __BOOTZ_STANDALONE__
+
+/// @brief These functions are used for x64 backends only. Do not try to use the same name for other backends, use their ISA specific conventions.
 
 using namespace Boot;
 

--- a/src/boot/src/New+Delete.cpp
+++ b/src/boot/src/New+Delete.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024-2025, Amlal El Mahrouss (amlal@nekernel.org)
+// Copyright 2024-2026, Amlal El Mahrouss (amlal@nekernel.org)
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 // Official repository: https://github.com/ne-foss-org/nekernel
 
@@ -13,6 +13,8 @@
 /// @param sz the size.
 /// @return
 void* operator new(size_t sz) {
+  if (sz == 0) ++sz;
+  
   void* buf = nullptr;
 
   while (BS->AllocatePool(EfiMemoryType::EfiLoaderData, sz, &buf) != kEfiOk);
@@ -24,6 +26,8 @@ void* operator new(size_t sz) {
 /// @param sz the size.
 /// @return
 void* operator new[](size_t sz) {
+  if (sz == 0) ++sz;
+  
   void* buf = nullptr;
   BS->AllocatePool(EfiMemoryType::EfiLoaderData, sz, &buf);
 
@@ -52,8 +56,7 @@ void operator delete[](void* buf) {
 void operator delete(void* buf, size_t size) {
   if (!buf) return;
 
-  NE_UNUSED(size);
-
+  SetMem(buf, 0, size);
   BS->FreePool(buf);
 }
 
@@ -63,8 +66,7 @@ void operator delete(void* buf, size_t size) {
 void operator delete[](void* buf, size_t size) {
   if (!buf) return;
 
-  NE_UNUSED(size);
-
+  SetMem(buf, 0, size);
   BS->FreePool(buf);
 }
 

--- a/src/boot/src/root/boot.ipxe.cfg
+++ b/src/boot/src/root/boot.ipxe.cfg
@@ -1,0 +1,54 @@
+#!ipxe
+
+# Figure out if we're capable of long-mode (64-bit addressing)
+cpuid --ext 29 && set arch x64 || set arch x86
+cpuid --ext 29 && set archl amd64 || set archl i386
+
+# Main Boot Menu
+:start
+menu iPXE boot menu
+item --gap --             -------------------------------Installation ------------------------------
+item --key w wds          BootZ
+item --gap --             ------------------------- Advanced options -------------------------------
+item --key c config       Configure settings
+item shell                Drop to iPXE shell
+item reboot               Reboot computer
+item
+item --key x exit         Exit iPXE and continue EFI boot
+choose --timeout 5000 --default boot_z selected || goto cancel
+set menu-timeout 0
+goto ${selected}
+
+# In case the user cancels the menu. 
+:cancel
+echo [NE_SYSTEM] You cancelled the menu, dropping you to a shell
+
+:shell
+echo [NE_SYSTEM] Type 'exit' to get the back to the menu
+shell
+set menu-timeout 0
+set submenu-timeout 0
+goto start
+
+:failed
+echo [NE_SYSTEM] Booting failed, dropping back to shell
+goto shell
+
+:reboot
+reboot
+
+:exit
+exit
+
+:config
+config
+goto start
+
+:back
+set submenu-timeout 0
+clear submenu-default
+goto start
+
+:boot_z
+chain EFI\BOOT\BOOTX64.EFI || goto failed
+goto start

--- a/src/libDDK/src/KernelTaskStub.S
+++ b/src/libDDK/src/KernelTaskStub.S
@@ -1,0 +1,13 @@
+/**
+ lang: asm
+ compiler: gnu
+ */
+
+.text
+
+/** @brief Sets up the stack frame from KernelTask's Start function. */
+__ddk_start:	
+#if defined(__DDK_AMD64__)
+	
+	ret
+#endif	


### PR DESCRIPTION
# [FEAT] Add KernelTaskStub.S for DDK's KernelTasks.

## Brief:

Adds iPXE support for BootZ. (ne_bootz is always used to bring-up ne_kernel to life)

