### PR TITLE
[KernelKit] scheduler sleep tracking + mutex priority inheritance

### DIFF
--- a/src/kernel/KernelKit/BinaryMutex.h
+++ b/src/kernel/KernelKit/BinaryMutex.h
@@ -8,12 +8,14 @@
 
 #include <CompilerKit/CompilerKit.h>
 #include <KernelKit/Timer.h>
+#include <KernelKit/CoreProcessScheduler.h>
 #include <NeKit/Config.h>
 
 namespace Kernel {
 class UserProcess;
 
 /// @brief Access control class, which locks a task until one is done.
+/// Implements priority inheritance to prevent priority inversion.
 class BinaryMutex final {
  public:
   using LockedPtr = UserProcess*;
@@ -37,6 +39,7 @@ class BinaryMutex final {
 
  private:
   LockedPtr fLockingProcess{nullptr};
+  AffinityKind fOwnerOriginalAffinity{AffinityKind::kInvalid};  // for priority inheritance
 };
 }  // namespace Kernel
 

--- a/src/kernel/KernelKit/UserProcessScheduler.h
+++ b/src/kernel/KernelKit/UserProcessScheduler.h
@@ -83,9 +83,10 @@ class UserProcess final {
     kExecutableKindCount,
   };
 
-  ProcessTime PTime{0};  //! @brief Process allocated tine.
+  ProcessTime PTime{0};  //! @brief Process allocated time.
   ProcessTime RTime{0};  //! @brief Process run time.
-  ProcessTime UTime{0};  //! #brief Process used time.
+  ProcessTime UTime{0};  //! @brief Process used time.
+  ProcessTime STime{0};  //! @brief Process sleep time (for dynamic priority boost).
 
   ProcessID      ProcessId{kCPSInvalidPID};
   ExecutableKind Kind{ExecutableKind::kExecutableKind};

--- a/src/kernel/src/BinaryMutex.cpp
+++ b/src/kernel/src/BinaryMutex.cpp
@@ -7,23 +7,15 @@
 #include <KernelKit/ProcessScheduler.h>
 
 namespace Kernel {
-/***********************************************************************************/
-/// @brief Unlocks the binary mutex.
-/***********************************************************************************/
-
-#ifndef __NE_TIMEOUT_CONFIG__
-#define __NE_TIMEOUT_CONFIG__ 10000
-#endif
 
 Bool BinaryMutex::Unlock() {
-  auto timeout = 0UL;
-  constexpr auto kTimoutLimit = __NE_TIMEOUT_CONFIG__;
+  if (!fLockingProcess)
+    return No;
 
-  while (fLockingProcess->Status == ProcessStatusKind::kRunning) {
-    ++timeout;
-
-    if (timeout > kTimoutLimit)
-      return No;
+  // restore original priority if we boosted the owner
+  if (fOwnerOriginalAffinity != AffinityKind::kInvalid) {
+    fLockingProcess->Affinity = fOwnerOriginalAffinity;
+    fOwnerOriginalAffinity = AffinityKind::kInvalid;
   }
 
   fLockingProcess = nullptr;
@@ -35,9 +27,20 @@ Bool BinaryMutex::Unlock() {
 /***********************************************************************************/
 
 Bool BinaryMutex::Lock(BinaryMutex::LockedPtr process) {
-  if (!process || this->IsLocked()) return No;
+  if (!process) return No;
+
+  // if already locked, implement priority inheritance
+  if (this->IsLocked() && fLockingProcess) {
+    // boost owner to waiter's priority if waiter is higher priority (lower value = higher priority)
+    if (process->Affinity < fLockingProcess->Affinity) {
+      fOwnerOriginalAffinity = fLockingProcess->Affinity;
+      fLockingProcess->Affinity = process->Affinity;
+    }
+    return No;  // lock not acquired, but owner boosted
+  }
 
   this->fLockingProcess = process;
+  fOwnerOriginalAffinity = AffinityKind::kInvalid;
 
   return Yes;
 }
@@ -51,15 +54,19 @@ Bool BinaryMutex::IsLocked() const {
 }
 
 /***********************************************************************************/
-/// @brief Try lock or wait.
+/// @brief Try lock, waiting until timeout if already locked.
 /***********************************************************************************/
 
 Bool BinaryMutex::LockAndWait(BinaryMutex::LockedPtr process, ITimer* timer) {
-  if (timer == nullptr) return No;
+  if (timer == nullptr || !process) return No;
 
+  // try to acquire lock immediately
+  if (this->Lock(process))
+    return Yes;
+
+  // wait and retry
   timer->Wait();
-  this->Lock(process);
-  return this->Unlock();
+  return this->Lock(process);
 }
 
 /***********************************************************************************/

--- a/src/kernel/src/UserProcessScheduler.cpp
+++ b/src/kernel/src/UserProcessScheduler.cpp
@@ -406,6 +406,7 @@ ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr im
   process.PTime     = 0;
   process.UTime     = 0;
   process.RTime     = 0;
+  process.STime     = 0;
 
   if (!process.FileTree) {
     process.FileTree = new ProcessFileTree<VoidPtr>();
@@ -501,6 +502,16 @@ SizeT UserProcessScheduler::Run() {
       ++process.UTime;
     }
 
+    //! boost priority for processes that slept (interactive boost)
+    if (process.STime > 0) {
+      // the longer it slept, the bigger the boost (capped at kVeryHigh level)
+      ProcessTime boost = process.STime / 10;
+      if (boost > (Int32)AffinityKind::kHigh)
+        boost = (Int32)AffinityKind::kHigh;
+      process.PTime += boost;
+      process.STime = 0;  // reset sleep counter after boost
+    }
+
     this->TheCurrentProcess() = process;
 
     if (UserProcessHelper::Switch(process.StackFrame, process.ProcessId)) {
@@ -520,6 +531,10 @@ SizeT UserProcessScheduler::Run() {
       }
     }
   } else {
+    //! track sleep time for processes that are blocked/waiting
+    if (process.Status == ProcessStatusKind::kFrozen) {
+      ++process.STime;
+    }
     ++process.RTime;
     --process.PTime;
   }


### PR DESCRIPTION
  ## Summary

- adds `STime` field to `UserProcess` for tracking sleep/blocked time
- boosts `PTime` proportionally when process wakes from sleep, improves interactive responsiveness
- implements priority inheritance in `BinaryMutex` to prevent priority inversion when high-priority task blocks on mutex held by low-priority task
- fixes broken `Unlock()` that was spinning in a loop waiting for process status change (made no sense)
- fixes `LockAndWait()` that was locking then immediately unlocking

## Modules affected

- `KernelKit/BinaryMutex.h`
- `KernelKit/UserProcessScheduler.h`
- `src/BinaryMutex.cpp`
- `src/UserProcessScheduler.cpp`

## Technical

**Sleep tracking**: processes in `kFrozen` status accumulate `STime`. when they become schedulable again, `PTime` gets boosted proportionally (capped at `kHigh` level). this makes I/O-bound and interactive tasks more responsive since they get priority when they wake up after sleeping.

**Priority inheritance**: when a process tries to `Lock()` a mutex already held by a lower-priority process, the owner gets temporarily boosted to the waiters priority. this prevents unbounded priority inversion where a medium-priority task can preempt the mutex owner indefinitely while a high-priority task waits. the original priority is restored on `Unlock()`.